### PR TITLE
Add support for core/audio and core/file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,8 @@ hooks.addFilter('blocks.registerBlockType', 'g-js.media.register', (settings, ty
   if(
     type === 'core/image' ||
     type === 'core/video' ||
+    type === 'core/audio' ||
+    type === 'core/file' ||
     type === 'core/media-text' ||
     type === 'core/cover'
   ) {


### PR DESCRIPTION
Add support for core/audio and core/file, which should not be left as temporary and get automatically removed by Drupal.

See https://www.drupal.org/project/gutenberg/issues/3106598 and https://www.drupal.org/project/gutenberg/issues/3173961

Are there any other file related plugins? It's quite problematic to not catch all of them, because the files will be left temporary (when not using the media module) and suddenly get removed.